### PR TITLE
Fixed reading some obsolete properties triggering warnings

### DIFF
--- a/Mindscape.Raygun4Unity/Messages/RaygunEnvironmentMessage.cs
+++ b/Mindscape.Raygun4Unity/Messages/RaygunEnvironmentMessage.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Text;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Mindscape.Raygun4Unity.Messages
 {
@@ -24,7 +25,7 @@ namespace Mindscape.Raygun4Unity.Messages
         FullScreen = Screen.fullScreen;
         Orientation = Screen.orientation.ToString();
 
-        LoadedLevelName = Application.loadedLevelName;
+        LoadedLevelName = SceneManager.GetActiveScene().name;
 
         ProcessorCount = SystemInfo.processorCount;
         Cpu = SystemInfo.processorType;
@@ -49,12 +50,12 @@ namespace Mindscape.Raygun4Unity.Messages
         SupportsGyroscope = SystemInfo.supportsGyroscope;
         SupportsInstancing = SystemInfo.supportsInstancing;
         SupportsLocationService = SystemInfo.supportsLocationService;
-        SupportsRenderTextures = SystemInfo.supportsRenderTextures;
+        SupportsRenderTextures = true;
         SupportsRenderToCubemap = SystemInfo.supportsRenderToCubemap;
         SupportsShadows = SystemInfo.supportsShadows;
         SupportsSparseTextures = SystemInfo.supportsSparseTextures;
-        SupportsStencil = SystemInfo.supportsStencil;
-        SupportsVertexPrograms = SystemInfo.supportsVertexPrograms;
+        SupportsStencil = 1;
+        SupportsVertexPrograms = true;
         SupportsVibration = SystemInfo.supportsVibration;
       }
       catch (Exception ex)


### PR DESCRIPTION
This PR removes the deprecation warning shown by Unity 2017.3. 

The deprecations are likely to come from Unity 5.0, back in 2015, so it makes sense to fix them.

I guess this repo is not really properly maintained, but still the plugin works and would be nice to get rid of these annoying warnings!